### PR TITLE
Fixes issues with requests that contain special characters.

### DIFF
--- a/app/controllers/spree/api/spree_signifyd/orders_controller.rb
+++ b/app/controllers/spree/api/spree_signifyd/orders_controller.rb
@@ -22,7 +22,7 @@ module Spree::Api::SpreeSignifyd
 
     def authorize
       request_sha = request.headers['HTTP_HTTP_X_SIGNIFYD_HMAC_SHA256']
-      computed_sha = build_sha(SpreeSignifyd::Config[:api_key], request.raw_post)
+      computed_sha = build_sha(SpreeSignifyd::Config[:api_key], encode_request(request.raw_post))
 
       head 401 unless Devise.secure_compare(request_sha, computed_sha)
     end

--- a/lib/spree_signifyd/request_verifier.rb
+++ b/lib/spree_signifyd/request_verifier.rb
@@ -1,6 +1,10 @@
 module SpreeSignifyd
   module RequestVerifier
 
+    def encode_request(request_body)
+      request_body.force_encoding('ISO-8859-1').encode('UTF-8')
+    end
+
     def build_sha(key, message)
       sha256 = OpenSSL::Digest::SHA256.new
       digest = OpenSSL::HMAC.digest(sha256, key, message)

--- a/spec/lib/spree_signifyd/request_verifier_spec.rb
+++ b/spec/lib/spree_signifyd/request_verifier_spec.rb
@@ -4,6 +4,20 @@ module SpreeSignifyd
   describe RequestVerifier do
     include RequestVerifier
 
+    describe "#encode_request" do
+      context "request has special characters" do
+        it "returns an unescaped UTF-8 string" do
+          expect(encode_request("R\xE9n\xE9 Pe\xF1a")).to eq "Réné Peña"
+        end
+      end
+
+      context "request doesn't contain special characters" do
+        it "returns the original string" do
+          expect(encode_request("John Doe")).to eq "John Doe"
+        end
+      end
+    end
+
     describe "#build_sha" do
       it "returns an HMAC SHA256 encoded message" do
         expect(build_sha('ABCDE', 'test')).to eq "K0y2rIeTA77lBEHP8cRPk64fVRbhMrZqEk7la39EjEM="


### PR DESCRIPTION
Change forces a UTF-8 encoding on the request data to ensure the SHA we generate is the same as the SHA sent by Signifyd.