### PR TITLE
Add support for --migrate=false

### DIFF
--- a/lib/generators/solidus_signifyd/install/install_generator.rb
+++ b/lib/generators/solidus_signifyd/install/install_generator.rb
@@ -2,6 +2,11 @@ module SolidusSignifyd
   module Generators
     class InstallGenerator < Rails::Generators::Base
       class_option :auto_run_migrations, type: :boolean, default: false
+      class_option :migrate, :type => :boolean, :default => true, :banner => 'Run migrations'
+
+      def prepare_options
+        @run_migrations = options[:migrate]
+      end
 
       source_root File.expand_path("../templates", __FILE__)
 
@@ -14,11 +19,14 @@ module SolidusSignifyd
       end
 
       def run_migrations
-        run_migrations = options[:auto_run_migrations] || ['', 'y', 'Y'].include?(ask 'Would you like to run the migrations now? [Y/n]')
-        if run_migrations
-          run 'bundle exec rake db:migrate'
-        else
-          puts 'Skipping rake db:migrate, don\'t forget to run it!'
+        if run_migrations= @run_migrations
+          run_migrations = options[:auto_run_migrations] || ['', 'y', 'Y'].include?(ask 'Would you like to run the migrations now? [Y/n]')
+          if run_migrations
+            run 'bundle exec rake db:migrate'
+          end
+        end
+        if !run_migrations
+          say_status :skipping, "migrations (don't forget to run rake db:migrate)"
         end
       end
     end


### PR DESCRIPTION
If --migrate=false is used, no interactive prompt is shown and
migrations are skipped.

If --migrate=true (the default) is used, the behavior remains
as before, i.e. the interactive prompt is shown unless
:auto_run_migrations = true is specified in the config.