### PR TITLE
Log order information sent to Signifyd

### DIFF
--- a/lib/spree_signifyd/create_signifyd_case.rb
+++ b/lib/spree_signifyd/create_signifyd_case.rb
@@ -6,6 +6,7 @@ module SpreeSignifyd
       Rails.logger.info "Processing Signifyd case creation event: #{order_number_or_id}"
       order = Spree::Order.find_by(number: order_number_or_id) || Spree::Order.find(order_number_or_id)
       order_data = JSON.parse(OrderSerializer.new(order).to_json)
+      Rails.logger.info "Order data sent to Signifyd for order #{order.number}: #{order_data}"
       Signifyd::Case.create(order_data, SpreeSignifyd::Config[:api_key])
     end
 


### PR DESCRIPTION
There were reports of some of the information for certain orders not being sent to Signifyd.

This extra logging will allow us to compare the information we’re sending against the information received by Signifyd.