### PR TITLE
Use active job for background processing.

### DIFF
--- a/lib/spree_signifyd.rb
+++ b/lib/spree_signifyd.rb
@@ -27,7 +27,7 @@ module SpreeSignifyd
 
   def create_case(order_number:)
     Rails.logger.info "Queuing Signifyd case creation event: #{order_number}"
-    Resque.enqueue(SpreeSignifyd::CreateSignifydCase, order_number)
+    SpreeSignifyd::CreateSignifydCase.perform_later(order_number)
   end
 
   def score_above_threshold?(score)

--- a/lib/spree_signifyd.rb
+++ b/lib/spree_signifyd.rb
@@ -3,7 +3,6 @@ require 'signifyd'
 require 'spree_signifyd/create_signifyd_case'
 require 'spree_signifyd/engine'
 require 'spree_signifyd/request_verifier'
-require 'resque'
 require 'devise'
 
 module SpreeSignifyd

--- a/lib/spree_signifyd/create_signifyd_case.rb
+++ b/lib/spree_signifyd/create_signifyd_case.rb
@@ -1,13 +1,12 @@
 module SpreeSignifyd
-  class CreateSignifydCase
-    @queue = :spree_backend_high
+  class CreateSignifydCase < ActiveJob::Base
+    queue_as :default
 
-    def self.perform(order_number_or_id)
+    def perform(order_number_or_id)
       Rails.logger.info "Processing Signifyd case creation event: #{order_number_or_id}"
       order = Spree::Order.find_by(number: order_number_or_id) || Spree::Order.find(order_number_or_id)
       order_data = JSON.parse(OrderSerializer.new(order).to_json)
       Signifyd::Case.create(order_data, SpreeSignifyd::Config[:api_key])
     end
-
   end
 end

--- a/solidus_signifyd.gemspec
+++ b/solidus_signifyd.gemspec
@@ -3,7 +3,7 @@
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = "solidus_signifyd"
-  s.version     = "1.0.1"
+  s.version     = "1.1.0"
   s.summary     = "Solidus extension for communicating with Signifyd to check orders for fraud."
   s.description = s.summary
 

--- a/solidus_signifyd.gemspec
+++ b/solidus_signifyd.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |s|
   s.requirements << "none"
 
   s.add_dependency "active_model_serializers", "0.9.3"
-  s.add_dependency "resque", "~> 1.25.1"
   s.add_dependency "signifyd", "~> 0.1.5"
   s.add_dependency "solidus", "~> 1.0"
   s.add_dependency "devise"

--- a/spec/lib/spree_signifyd/create_signifyd_case_spec.rb
+++ b/spec/lib/spree_signifyd/create_signifyd_case_spec.rb
@@ -8,12 +8,12 @@ module SpreeSignifyd
 
       it "calls Signifyd::Case#create with the correct params" do
         expect(Signifyd::Case).to receive(:create).with(json, SpreeSignifyd::Config[:api_key])
-        CreateSignifydCase.perform(order.id)
+        CreateSignifydCase.perform_now(order.id)
       end
 
       it "calls Signifyd::Case#create with the correct params" do
         expect(Signifyd::Case).to receive(:create).with(json, SpreeSignifyd::Config[:api_key])
-        CreateSignifydCase.perform(order.number)
+        CreateSignifydCase.perform_now(order.number)
       end
     end
   end

--- a/spec/lib/spree_signifyd_spec.rb
+++ b/spec/lib/spree_signifyd_spec.rb
@@ -65,8 +65,7 @@ module SpreeSignifyd
 
     describe ".create_case" do
       it 'enqueues in resque' do
-        expect(Resque).to receive(:enqueue).with(SpreeSignifyd::CreateSignifydCase, 111)
-        SpreeSignifyd.create_case(order_number: 111)
+        expect { SpreeSignifyd.create_case(order_number: 111) }.to have_enqueued_job(SpreeSignifyd::CreateSignifydCase)
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -38,6 +38,7 @@ RSpec.configure do |config|
   config.run_all_when_everything_filtered = true
   config.use_transactional_fixtures = false
 
+  config.include RSpec::Rails::Matchers
   config.include FactoryGirl::Syntax::Methods
 
   # Ensure Suite is set to use transactions for speed.
@@ -50,6 +51,7 @@ RSpec.configure do |config|
   config.before :each do
     DatabaseCleaner.strategy = example.metadata[:js] ? :truncation : :transaction
     DatabaseCleaner.start
+    ActiveJob::Base.queue_adapter = :test
 
     allow(Signifyd::Case).to receive(:create).and_return(
       { code: 201, body: { investigationId: 123 } }


### PR DESCRIPTION
Active job adapters let the user choose what backend implementation they want to use for processing, we shouldn't have to force resque on them.