### PR TITLE
Fix authenticity header

### DIFF
--- a/app/controllers/spree/api/spree_signifyd/orders_controller.rb
+++ b/app/controllers/spree/api/spree_signifyd/orders_controller.rb
@@ -21,7 +21,7 @@ module Spree::Api::SpreeSignifyd
     private
 
     def authorize
-      request_sha = request.headers['HTTP_HTTP_X_SIGNIFYD_HMAC_SHA256']
+      request_sha = request.headers['HTTP_X_SIGNIFYD_SEC_HMAC_SHA256']
       computed_sha = build_sha(SpreeSignifyd::Config[:api_key], request.raw_post)
 
       if !Devise.secure_compare(request_sha, computed_sha)

--- a/spec/controllers/spree/api/spree_signifyd/orders_controller_spec.rb
+++ b/spec/controllers/spree/api/spree_signifyd/orders_controller_spec.rb
@@ -38,7 +38,7 @@ module Spree::Api::SpreeSignifyd
           }
       }
 
-      before { request.headers['HTTP_HTTP_X_SIGNIFYD_HMAC_SHA256'] = signifyd_sha }
+      before { request.headers['HTTP_X_SIGNIFYD_SEC_HMAC_SHA256'] = signifyd_sha }
 
       around do |example|
         previous_api_key = SpreeSignifyd::Config[:api_key]


### PR DESCRIPTION
I don't know when this changed, but this is the header listed in the docs (minus the bonus HTTP_ because of rails) and it's been the header used in the Magento plugin since the beginning of time.

> To allow a client to verify a webhook message has in fact come from SIGNIFYD, an `X-SIGNIFYD-SEC-HMAC-SHA256` header is included in each webhook POST message.
>
> https://www.signifyd.com/docs/api/#/reference/webhooks/get-a-case