### PR TITLE
Use json-schema to validate our outgoing cases

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem 'pg'
 gem 'mysql2'
 
 group :development, :test do
+  gem 'json-schema'
   gem "pry-rails"
 end
 

--- a/app/serializers/spree_signifyd/credit_card_serializer.rb
+++ b/app/serializers/spree_signifyd/credit_card_serializer.rb
@@ -9,8 +9,8 @@ module SpreeSignifyd
     # this is how to conditionally include attributes in AMS
     def attributes(*args)
       hash = super
-      hash[:expiryMonth] = object.month if object.month
-      hash[:expiryYear] = object.year if object.year
+      hash[:expiryMonth] = object.month.to_i if object.month
+      hash[:expiryYear] = object.year.to_i if object.year
       hash
     end
 

--- a/app/serializers/spree_signifyd/credit_card_serializer.rb
+++ b/app/serializers/spree_signifyd/credit_card_serializer.rb
@@ -4,7 +4,15 @@ module SpreeSignifyd
   class CreditCardSerializer < ActiveModel::Serializer
     self.root = false
 
-    attributes :cardHolderName, :last4, :expiryMonth, :expiryYear
+    attributes :cardHolderName, :last4
+
+    # this is how to conditionally include attributes in AMS
+    def attributes(*args)
+      hash = super
+      hash[:expiryMonth] = object.month if object.month
+      hash[:expiryYear] = object.year if object.year
+      hash
+    end
 
     def cardHolderName
       "#{object.first_name} #{object.last_name}"
@@ -12,14 +20,6 @@ module SpreeSignifyd
 
     def last4
       object.last_digits
-    end
-
-    def expiryMonth
-      object.month
-    end
-
-    def expiryYear
-      object.year
     end
   end
 end

--- a/app/serializers/spree_signifyd/order_serializer.rb
+++ b/app/serializers/spree_signifyd/order_serializer.rb
@@ -48,8 +48,8 @@ module SpreeSignifyd
         'currency' => object.currency,
         'totalPrice' => object.total,
         'products' => products,
-        'avsResponseCode' => latest_payment.try!(:avs_response),
-        'cvvResponseCode' => latest_payment.try!(:cvv_response_code)
+        'avsResponseCode' => latest_payment.try!(:avs_response) || "",
+        'cvvResponseCode' => latest_payment.try!(:cvv_response_code) || ""
       }
     end
 

--- a/app/serializers/spree_signifyd/order_serializer.rb
+++ b/app/serializers/spree_signifyd/order_serializer.rb
@@ -46,7 +46,7 @@ module SpreeSignifyd
         'orderId' => object.number,
         'createdAt' => object.completed_at.utc.iso8601,
         'currency' => object.currency,
-        'totalPrice' => object.total,
+        'totalPrice' => object.total.to_f,
         'products' => products,
         'avsResponseCode' => latest_payment.try!(:avs_response) || "",
         'cvvResponseCode' => latest_payment.try!(:cvv_response_code) || ""

--- a/app/serializers/spree_signifyd/order_serializer.rb
+++ b/app/serializers/spree_signifyd/order_serializer.rb
@@ -42,7 +42,7 @@ module SpreeSignifyd
 
     def build_purchase_information
       {
-        'browserIpAddress' => object.last_ip_address,
+        'browserIpAddress' => object.last_ip_address || "",
         'orderId' => object.number,
         'createdAt' => object.completed_at.utc.iso8601,
         'currency' => object.currency,

--- a/app/serializers/spree_signifyd/user_serializer.rb
+++ b/app/serializers/spree_signifyd/user_serializer.rb
@@ -31,7 +31,7 @@ module SpreeSignifyd
     end
 
     def aggregateOrderDollars
-      completed_orders.sum(:total)
+      completed_orders.sum(:total).to_f
     end
 
     private

--- a/app/serializers/spree_signifyd/user_serializer.rb
+++ b/app/serializers/spree_signifyd/user_serializer.rb
@@ -41,6 +41,10 @@ module SpreeSignifyd
       completed_orders.sum(:total).to_f
     end
 
+    def phone
+      object.orders.order("created_at DESC").first.try!(:ship_address).try!(:phone)
+    end
+
     private
 
     def completed_orders

--- a/app/serializers/spree_signifyd/user_serializer.rb
+++ b/app/serializers/spree_signifyd/user_serializer.rb
@@ -4,7 +4,14 @@ module SpreeSignifyd
   class UserSerializer < ActiveModel::Serializer
     self.root = false
 
-    attributes :emailAddress, :username, :createdDate, :lastUpdateDate, :lastOrderId, :aggregateOrderCount, :aggregateOrderDollars
+    attributes :emailAddress, :username, :createdDate, :lastUpdateDate, :aggregateOrderCount, :aggregateOrderDollars, :phone
+
+    # this is how to conditionally include attributes in AMS
+    def attributes(*args)
+      hash = super
+      hash[:lastOrderId] = lastOrderId if lastOrderId.present?
+      hash
+    end
 
     def emailAddress
       object.email

--- a/spec/serializers/spree_signifyd/credit_card_serializer_spec.rb
+++ b/spec/serializers/spree_signifyd/credit_card_serializer_spec.rb
@@ -15,11 +15,11 @@ module SpreeSignifyd
       end
 
       it "expiryMonth" do
-        expect(serialized_credit_card['expiryMonth']).to eq credit_card.month
+        expect(serialized_credit_card['expiryMonth']).to eq credit_card.month.to_i
       end
 
       it "expiryYear" do
-        expect(serialized_credit_card['expiryYear']).to eq credit_card.year
+        expect(serialized_credit_card['expiryYear']).to eq credit_card.year.to_i
       end
     end
   end

--- a/spec/serializers/spree_signifyd/order_serializer_spec.rb
+++ b/spec/serializers/spree_signifyd/order_serializer_spec.rb
@@ -9,6 +9,17 @@ module SpreeSignifyd
     let(:line_item) { order.line_items.first }
     let(:serialized_order) { JSON.parse(OrderSerializer.new(order).to_json) }
 
+    describe 'document format' do
+      before do
+        # we can't pass payments into the :shipped_order factory
+        order.payments.last.update(avs_response: "M", cvv_response_code: "M")
+      end
+
+      it 'matches the SIGNIFYD V2 api' do
+        expect(serialized_order).to match_schema('v2/case.json')
+      end
+    end
+
     describe "node values" do
       context "purchase" do
 

--- a/spec/serializers/spree_signifyd/order_serializer_spec.rb
+++ b/spec/serializers/spree_signifyd/order_serializer_spec.rb
@@ -21,8 +21,8 @@ module SpreeSignifyd
         it { expect(purchase['totalPrice']).to eq order.total.to_s }
 
         context "with a payment" do
-          it { expect(purchase['avsResponseCode']).to eq order.payments.last.avs_response }
-          it { expect(purchase['cvvResponseCode']).to eq order.payments.last.cvv_response_code }
+          it { expect(purchase['avsResponseCode']).to eq order.payments.last.avs_response.to_s }
+          it { expect(purchase['cvvResponseCode']).to eq order.payments.last.cvv_response_code.to_s }
 
           context "when the payment is a paypal payment" do
             before do
@@ -46,8 +46,8 @@ module SpreeSignifyd
         context "without a payment" do
           let(:order) { create(:completed_order_with_totals) }
 
-          it { expect(purchase['avsResponseCode']).to be nil }
-          it { expect(purchase['cvvResponseCode']).to be nil }
+          it { expect(purchase['avsResponseCode']).to eq "" }
+          it { expect(purchase['cvvResponseCode']).to eq "" }
         end
 
         it "contains a products node" do

--- a/spec/serializers/spree_signifyd/order_serializer_spec.rb
+++ b/spec/serializers/spree_signifyd/order_serializer_spec.rb
@@ -2,7 +2,10 @@ require 'spec_helper'
 
 module SpreeSignifyd
   describe OrderSerializer do
-    let(:order) { create(:shipped_order, line_items_count: 1) }
+    let(:order) { create :shipped_order,
+      line_items_count: 1,
+      last_ip_address: "127.0.0.1"
+    }
     let(:line_item) { order.line_items.first }
     let(:serialized_order) { JSON.parse(OrderSerializer.new(order).to_json) }
 

--- a/spec/serializers/spree_signifyd/order_serializer_spec.rb
+++ b/spec/serializers/spree_signifyd/order_serializer_spec.rb
@@ -18,7 +18,7 @@ module SpreeSignifyd
         it { expect(purchase['orderId']).to eq order.number }
         it { expect(purchase['createdAt']).to eq order.completed_at.utc.iso8601 }
         it { expect(purchase['currency']).to eq order.currency }
-        it { expect(purchase['totalPrice']).to eq order.total.to_s }
+        it { expect(purchase['totalPrice']).to eq order.total }
 
         context "with a payment" do
           it { expect(purchase['avsResponseCode']).to eq order.payments.last.avs_response.to_s }

--- a/spec/serializers/spree_signifyd/user_serializer_spec.rb
+++ b/spec/serializers/spree_signifyd/user_serializer_spec.rb
@@ -22,6 +22,10 @@ module SpreeSignifyd
        expect(serialized_user['username']).to eq user.email
       end
 
+      it "phone" do
+        expect(serialized_user['phone']).to eq new_complete_order.ship_address.phone
+      end
+
       it "createdDate" do
        expect(serialized_user['createdDate']).to eq user.created_at.utc.iso8601
       end

--- a/spec/serializers/spree_signifyd/user_serializer_spec.rb
+++ b/spec/serializers/spree_signifyd/user_serializer_spec.rb
@@ -50,7 +50,7 @@ module SpreeSignifyd
       end
 
       it "aggregateOrderDollars" do
-        expect(serialized_user['aggregateOrderDollars']).to eq (old_complete_order.total + new_complete_order.total).to_s
+        expect(serialized_user['aggregateOrderDollars']).to eq (old_complete_order.total + new_complete_order.total)
       end
     end
   end

--- a/spec/support/api_schema_matcher.rb
+++ b/spec/support/api_schema_matcher.rb
@@ -1,0 +1,7 @@
+RSpec::Matchers.define :match_schema do |schema|
+  match do |candidate|
+    schema_directory = File.expand_path("../schemas",  __FILE__)
+    schema_path = File.join(schema_directory, schema)
+    JSON::Validator.validate!(schema_path, candidate)
+  end
+end

--- a/spec/support/schemas/v2/case.json
+++ b/spec/support/schemas/v2/case.json
@@ -1,0 +1,305 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "purchase": {
+      "type": "object",
+      "description": "The purchase.",
+      "properties": {
+        "browserIpAddress": {
+          "type": "string",
+          "description": "The IP Address of the browser that was used to make the  This is the IP Address that was used to connect to your site and make the "
+        },
+        "shipments": {
+          "type": "array",
+          "description": "The shipments association with this purchase"
+        },
+        "products": {
+          "type": "array",
+          "description": "The products purchased in the transaction."
+        },
+        "orderId": {
+          "type": "string",
+          "description": "A string uniquely identifying this order."
+        },
+        "createdAt": {
+          "type": "string",
+          "description": "`yyyy-MM-dd'T'HH:mm:ssZ` The date and time when the order was placed, shown on the signifyd console. See the Dates section of these docs for more information about date formats."
+        },
+        "paymentGateway": {
+          "type": "string",
+          "description": "The gateway that processed the transaction. For paypal orders use paypal_account."
+        },
+        "paymentMethod": {
+          "type": "object",
+          "description": "The method the user used to complete the "
+        },
+        "transactionId": {
+          "type": "string",
+          "description": "The unique identifier provided by the payment gateway for this order. If you have provided us with credentials for your payment gateway we can obtain additional details about the order, like AVS and CVV status, from your payment provider."
+        },
+        "currency": {
+          "type": "string",
+          "description": "The currency type of the order, in 3 letter ISO 4217 format. Defaults to USD."
+        },
+        "avsResponseCode": {
+          "type": "string",
+          "description": "The response code from the address verification system (AVS). Accepted codes: http://www.emsecommerce.net/avs_cvv2_response_codes.htm"
+        },
+        "cvvResponseCode": {
+          "type": "string",
+          "description": "The response code from the card verification value (CVV) check. Accepted codes listed on above link."
+        },
+        "orderChannel": {
+          "type": "string",
+          "description": "The method used by the buyer to place the order. Either WEB or PHONE."
+        },
+        "receivedBy": {
+          "type": "string",
+          "description": "If the order was was taken by a customer service or sales agent, his or her name."
+        },
+        "totalPrice": {
+          "type": "number",
+          "description": "The total price of the order, including shipping price and taxes."
+        }
+      },
+      "required": [
+        "browserIpAddress",
+        "orderId",
+        "createdAt",
+        "avsResponseCode",
+        "cvvResponseCode",
+        "totalPrice"
+      ]
+    },
+    "recipient": {
+      "type": "object",
+      "description": "The person receiving the goods.",
+      "properties": {
+        "fullName": {
+          "type": "string",
+          "description": "The full name of the person receiving the goods. If this item is being shipped, then this field is the person it is being shipping to. Don't assume this name is the same as card.cardHolderName. Only put a value here if the name will actually appear on the shipping label. If this item is digital, then this field will likely be blank."
+        },
+        "confirmationEmail": {
+          "type": "string",
+          "description": "When this purchase was completed, you likely sent a confirmation email or you will be sending a confirmation email to someone once you approve the order. This is the email address to which that confirmation email will be sent."
+        },
+        "confirmationPhone": {
+          "type": "string",
+          "description": "The phone number that you would call if there was something wrong with this order or the phone number that was supplied with the shipping information."
+        },
+        "organization": {
+          "type": "string",
+          "description": "If provided by the buyer, the name of the recipient's company or organization."
+        },
+        "deliveryAddress": {
+          "type": "object",
+          "description": "The address to which the order will be delivered.",
+          "properties": {
+            "streetAddress": {
+              "type": "string",
+              "description": "The street number and street name."
+            },
+            "unit": {
+              "type": "string",
+              "description": "The unit or apartment number."
+            },
+            "city": {
+              "type": "string",
+              "description": "The city name."
+            },
+            "provinceCode": {
+              "type": "string",
+              "description": "The code or abbreviation for the province."
+            },
+            "postalCode string": {
+              "type": "string",
+              "description": "The postal code."
+            },
+            "countryCode": {
+              "type": "string",
+              "description": "The two-letter ISO-3166 country code. If left blank, we will assume US."
+            },
+            "latitude": {
+              "type": "number",
+              "description": "The latitude of the address. Used when address details are not provided. Ignored otherwise."
+            },
+            "longitude": {
+              "type": "number",
+              "description": "The longitude of the address. Used when address details are not provided. Ignored otherwise."
+            }
+          }
+        }
+      },
+      "required": [
+        "fullName",
+        "confirmationEmail",
+        "deliveryAddress"
+      ]
+    },
+    "card": {
+      "type": "object",
+      "properties": {
+        "cardHolderName": {
+          "type": "string",
+          "description": "The full name on the credit card that was charged."
+        },
+        "bin": {
+          "type": "number",
+          "description": "The first six digits of the credit card, the bank identification number, which uniquely identifies the issuer."
+        },
+        "last4": {
+          "type": "string",
+          "description": "The last four digits of the card number."
+        },
+        "expiryMonth": {
+          "type": "number",
+          "description": "MM representation of the expiration month of the card."
+        },
+        "expiryYear": {
+          "type": "number",
+          "description": "yyyy representation of the expiration year of the card."
+        },
+        "billingAddress": {
+          "type": "object",
+          "properties": {
+            "streetAddress": {
+              "type": "string",
+              "description": "The street number and street name."
+            },
+            "unit": {
+              "type": "string",
+              "description": "The unit or apartment number."
+            },
+            "city": {
+              "type": "string",
+              "description": "The city name."
+            },
+            "provinceCode": {
+              "type": "string",
+              "description": "The code or abbreviation for the province."
+            },
+            "postalCode string": {
+              "type": "string",
+              "description": "The postal code."
+            },
+            "countryCode": {
+              "type": "string",
+              "description": "The two-letter ISO-3166 country code. If left blank, we will assume US."
+            },
+            "latitude": {
+              "type": "number",
+              "description": "The latitude of the address. Used when address details are not provided. Ignored otherwise."
+            },
+            "longitude": {
+              "type": "number",
+              "description": "The longitude of the address. Used when address details are not provided. Ignored otherwise."
+            }
+          },
+          "description": "The billing address for the card."
+        }
+      },
+      "required": [
+        "cardHolderName",
+        "billingAddress"
+      ]
+    },
+    "userAccount": {
+      "type": "object",
+      "properties": {
+        "email": {
+          "type": "string",
+          "description": "The primary email address associated with the account."
+        },
+        "username": {
+          "type": "string",
+          "description": "The username associated with the account. Please supply this even if it is the same as the email address."
+        },
+        "phone": {
+          "type": "string",
+          "description": "The phone number association with the account."
+        },
+        "createdDate": {
+          "type": "string",
+          "description": "`yyyy-MM-dd'T'HH:mm:ssZ` The date when the account was created. See the Dates section of these docs for more information about date formats."
+        },
+        "accountNumber": {
+          "type": "string",
+          "description": "Your unique identifier for the account."
+        },
+        "lastOrderId": {
+          "type": "string",
+          "description": "The unique identifier for the last order placed by this account, prior to the current order."
+        },
+        "aggregateOrderCount": {
+          "type": "number",
+          "description": "The total count of orders placed by this account since it was created, including the current order."
+        },
+        "aggregateOrderDollars": {
+          "type": "number",
+          "description": "The total amount spent by this account since it was created, including the current order."
+        },
+        "lastUpdateDate": {
+          "type": "string",
+          "description": "`yyyy-MM-dd'T'HH:mm:ssZ` The last time a change was made to this account other than an order being placed. Examples include changing email addresses or adding a new credit card. See the Dates section of these docs for more information about date formats."
+        }
+      }
+    },
+    "seller": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The business name of the seller."
+        },
+        "domain": {
+          "type": "string",
+          "description": "The domain of the seller."
+        },
+        "shipFromAddress": {
+          "type": "object",
+          "properties": {
+            "streetAddress": {
+              "type": "string",
+              "description": "The street number and street name."
+            },
+            "unit": {
+              "type": "string",
+              "description": "The unit or apartment number."
+            },
+            "city": {
+              "type": "string",
+              "description": "The city name."
+            },
+            "provinceCode": {
+              "type": "string",
+              "description": "The code or abbreviation for the province."
+            },
+            "postalCode string": {
+              "type": "string",
+              "description": "The postal code."
+            },
+            "countryCode": {
+              "type": "string",
+              "description": "The two-letter ISO-3166 country code. If left blank, we will assume US."
+            },
+            "latitude": {
+              "type": "number",
+              "description": "The latitude of the address. Used when address details are not provided. Ignored otherwise."
+            },
+            "longitude": {
+              "type": "number",
+              "description": "The longitude of the address. Used when address details are not provided. Ignored otherwise."
+            }
+          },
+          "description": "The location from which the seller shipped the order."
+        }
+      }
+    }
+  },
+  "required": [
+    "purchase",
+    "recipient",
+    "card"
+  ]
+}


### PR DESCRIPTION
We serialize order information to send to SIGNIFYD. Their API provides a (mostly valid) json-schema that we can use to validate our payloads. I have included a lightly modified version of their schema, which has been edited for format.

Validation is provided by https://github.com/ruby-json-schema/json-schema

