### PR TITLE
Add option to skip store credit orders

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,34 @@ http://www.example.com/api/spree_signifyd/orders
 
 Cases can be inspected in the SIGNIFYD web console.
 
-### Risky Orders
+Configuration
+-------------
+
+### api_key
+
+Type: `string`
+
+SIGNIFYD team API key.
+
+### exclude_store_credit_orders
+
+Type: `boolean`
+Default: `false`
+
+By default, even orders which are fully paid with store credit are sent to
+SIGNIFYD. Since this could result in unnecessary charges to a user who is on a
+"flat rate" plan, we provide the option to skip these orders.
+
+### signifyd_score_threshold
+
+Type: `integer`
+Default: `500`
+
+Automatic approval is granted to orders which have a good "reviewDisposition" or
+have a score greater than the `signifyd_score_threshold`.
+
+Risky Orders
+------------
 
 Flagging a case as bad in the SIGNIFYD web console will associate
 a fraudulent case with the order's email. This will cause future orders to drop

--- a/app/models/spree/signifyd_configuration.rb
+++ b/app/models/spree/signifyd_configuration.rb
@@ -1,6 +1,7 @@
 module Spree
   class SignifydConfiguration < Preferences::Configuration
     preference :api_key, :string
+    preference :exclude_store_credit_orders, :boolean, default: false
     preference :signifyd_score_threshold, :integer, default: 500 # Signifyd's recommended threshold
   end
 end

--- a/app/models/spree_signifyd/order_concerns.rb
+++ b/app/models/spree_signifyd/order_concerns.rb
@@ -3,7 +3,11 @@ module SpreeSignifyd::OrderConcerns
 
   included do
     Spree::Order.state_machine.after_transition to: :complete, unless: :approved? do |order, transition|
-      SpreeSignifyd.create_case(order_number: order.number)
+      if order.send_to_signifyd?
+        SpreeSignifyd.create_case(order_number: order.number)
+      else
+        SpreeSignifyd.approve(order: order)
+      end
     end
 
     has_one :signifyd_order_score, class_name: "SpreeSignifyd::OrderScore"
@@ -18,6 +22,19 @@ module SpreeSignifyd::OrderConcerns
 
     def awaiting_approval?
       !signifyd_order_score
+    end
+
+    def send_to_signifyd?
+      !approved? &&
+      !(SpreeSignifyd::Config[:exclude_store_credit_orders] && paid_completely_with_store_credit?)
+    end
+
+    private
+
+    def paid_completely_with_store_credit?
+      payments.all? do |payment|
+        payment.payment_method.is_a?(Spree::PaymentMethod::StoreCredit)
+      end
     end
   end
 end

--- a/app/serializers/spree_signifyd/order_serializer.rb
+++ b/app/serializers/spree_signifyd/order_serializer.rb
@@ -37,7 +37,7 @@ module SpreeSignifyd
     private
 
     def paid_by_paypal?
-      latest_payment.try!(:source) && latest_payment.source.cc_type == "paypal"
+      latest_payment.try!(:source).try(:cc_type) == "paypal"
     end
 
     def build_purchase_information

--- a/lib/spree_signifyd/engine.rb
+++ b/lib/spree_signifyd/engine.rb
@@ -11,6 +11,7 @@ module SpreeSignifyd
 
     initializer "spree.signifyd.environment", before: :load_config_initializers do |app|
       SpreeSignifyd::Config = Spree::SignifydConfiguration.new
+      SpreeSignifyd::Config.use_static_preferences!
     end
 
     def self.activate

--- a/spec/controllers/spree/api/spree_signifyd/orders_controller_spec.rb
+++ b/spec/controllers/spree/api/spree_signifyd/orders_controller_spec.rb
@@ -38,13 +38,9 @@ module Spree::Api::SpreeSignifyd
           }
       }
 
-      before { request.headers['HTTP_X_SIGNIFYD_SEC_HMAC_SHA256'] = signifyd_sha }
-
-      around do |example|
-        previous_api_key = SpreeSignifyd::Config[:api_key]
+      before do
+        request.headers['HTTP_X_SIGNIFYD_SEC_HMAC_SHA256'] = signifyd_sha
         SpreeSignifyd::Config[:api_key] = 'ABCDE'
-        example.run
-        SpreeSignifyd::Config[:api_key] = previous_api_key
       end
 
       routes { Spree::Core::Engine.routes }

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -32,20 +32,47 @@ describe Spree::Order, :type => :model do
 
   describe "transition to complete" do
     let(:order) { create(:order_with_line_items, state: 'confirm') }
-    let!(:payment) { create(:payment, amount: order.total, order: order ) }
 
-    it "calls #create_signifyd_case" do
-      expect(SpreeSignifyd).to receive(:create_case).with(order_number: order.number)
-      order.complete!
+    shared_examples "an order we send to signifyd" do
+      it "creates a new SIGNIFYD case" do
+        expect(SpreeSignifyd).to receive(:create_case).with(order_number: order.number)
+        order.complete!
+      end
     end
 
-    context "the order is already approved" do # e.g. unreturned exchanges are automatically approved
-      it "does not create a case" do
-        order.contents.approve(user: Spree.user_class.first)
+    shared_examples "an order we DO NOT send to signifyd" do
+      it "does not create a new SIGNIFYD case" do
         expect(SpreeSignifyd).not_to receive(:create_case)
         order.complete!
       end
     end
-  end
 
+    context "paid with store credit only" do
+      let!(:payment) { create(:store_credit_payment, amount: order.total, order: order ) }
+
+      it_behaves_like "an order we send to signifyd"
+
+      context "don't send store credit orders to SIGNIFYD" do
+        before { SpreeSignifyd::Config[:exclude_store_credit_orders] = true }
+
+        it_behaves_like "an order we DO NOT send to signifyd"
+
+        it "is immediately approved" do
+          expect{ order.complete! }.to change{ order.approved? }.from(false).to(true)
+        end
+      end
+    end
+
+    context "paid with cash" do
+      let!(:payment) { create(:payment, amount: order.total, order: order ) }
+
+      it_behaves_like "an order we send to signifyd"
+
+      context "the order is already approved" do # e.g. unreturned exchanges are automatically approved
+        before { order.contents.approve(user: Spree.user_class.first) }
+
+        it_behaves_like "an order we DO NOT send to signifyd"
+      end
+    end
+  end
 end

--- a/spec/serializers/spree_signifyd/order_serializer_spec.rb
+++ b/spec/serializers/spree_signifyd/order_serializer_spec.rb
@@ -55,7 +55,10 @@ module SpreeSignifyd
         end
 
         context "paid with store credit" do
-          let(:order) { create :shipped_order, payment_type: :store_credit_payment}
+          before do
+            create(:store_credit_payment, amount: order.total, order: order)
+            order.payments.reload
+          end
 
           it { expect(serialized_order["card"]).to eq({}) }
         end

--- a/spec/serializers/spree_signifyd/order_serializer_spec.rb
+++ b/spec/serializers/spree_signifyd/order_serializer_spec.rb
@@ -54,6 +54,12 @@ module SpreeSignifyd
           end
         end
 
+        context "paid with store credit" do
+          let(:order) { create :shipped_order, payment_type: :store_credit_payment}
+
+          it { expect(serialized_order["card"]).to eq({}) }
+        end
+
         context "without a payment" do
           let(:order) { create(:completed_order_with_totals) }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -47,6 +47,11 @@ RSpec.configure do |config|
     DatabaseCleaner.clean_with :truncation
   end
 
+  # allow us to test various preference settings without cross contamination
+  config.before :each do
+    SpreeSignifyd::Config.reset
+  end
+
   # Before each spec check if it is a Javascript test and switch between using database transactions or not where necessary.
   config.before :each do
     DatabaseCleaner.strategy = example.metadata[:js] ? :truncation : :transaction


### PR DESCRIPTION
In the event that an order is completely paid by store credit, it makes little sense to send to SIGNIFYD if you have to pay them for every order they process. For those users we offer the option to immediately approve orders which have only store credit payments and avoid creating a
SIGNIFYD case entirely.
