### PR TITLE
Prevent transition error on approval

### DIFF
--- a/lib/spree_signifyd.rb
+++ b/lib/spree_signifyd.rb
@@ -19,7 +19,7 @@ module SpreeSignifyd
 
   def approve(order:)
     order.contents.approve(name: self.name)
-    order.shipments.each { |shipment| shipment.ready! if shipment.pending? }
+    order.shipments.each { |shipment| shipment.ready! if shipment.can_ready? }
     order.updater.update_shipment_state
     order.save!
   end

--- a/spec/lib/spree_signifyd_spec.rb
+++ b/spec/lib/spree_signifyd_spec.rb
@@ -61,6 +61,18 @@ module SpreeSignifyd
           expect { approve }.to change { order.approved_at }
         end
       end
+
+      context "with backordered stock" do
+        before do
+          order.inventory_units.first.update(state: 'backordered')
+          order.reload
+        end
+
+        it "does not attempt invalid state changes" do
+          approve
+          expect(order.reload.shipments.first).to be_pending
+        end
+      end
     end
 
     describe ".create_case" do


### PR DESCRIPTION
Right now we're trying to ship shipments which cannot be shipped. This results in explosions. Let's leave it up to the application to do it's own shipping when it sees fit (eg: during backorder fulfilment).