### PR TITLE
Allow canceled shipments to remain canceled

### DIFF
--- a/app/models/spree_signifyd/shipment_decorator.rb
+++ b/app/models/spree_signifyd/shipment_decorator.rb
@@ -2,7 +2,7 @@ module SpreeSignifyd
   module ShipmentDecorator
 
     def determine_state(order)
-      return 'pending' if (pending? || canceled?) && !order.approved?
+      return 'pending' if pending? && !order.approved?
       super(order)
     end
   end

--- a/spec/models/spree/shipment_spec.rb
+++ b/spec/models/spree/shipment_spec.rb
@@ -7,9 +7,12 @@ describe Spree::Shipment, :type => :model do
 
   describe "#determine_state_with_signifyd" do
     context "with a canceled order" do
-      before { shipment.order.update_columns(state: 'canceled') }
+      before do
+        shipment.order.update(state: 'canceled')
+        shipment.update(state: 'canceled')
+      end
 
-      it "canceled shipments remain canceled", pending: true do
+      it "canceled shipments remain canceled" do
         expect(subject).to eq "canceled"
       end
     end

--- a/spec/models/spree/shipment_spec.rb
+++ b/spec/models/spree/shipment_spec.rb
@@ -6,52 +6,28 @@ describe Spree::Shipment, :type => :model do
   subject { shipment.determine_state(shipment.order) }
 
   describe "#determine_state_with_signifyd" do
+    context "with a canceled order" do
+      before { shipment.order.update_columns(state: 'canceled') }
 
-    context "with a risky order" do
-      before { allow(shipment.order).to receive(:is_risky?).and_return(true) }
-
-      context "the order is not approved" do
-        it "returns pending" do
-          allow(shipment.order).to receive(:approved?).and_return(false)
-          expect(subject).to eq "pending"
-        end
+      it "canceled shipments remain canceled", pending: true do
+        expect(subject).to eq "canceled"
       end
+    end
 
-      context "the order is approved" do
+    context "with an approved order" do
+      before { shipment.order.contents.approve(name: 'test approver') }
+
+      it "pending shipments remain pending" do
+        expect(subject).to eq "pending"
+      end
+    end
+
+    [:shipped, :ready].each do |state|
+      context "the shipment is #{state}" do
+        before { shipment.update(state: state) }
         it "defaults to existing behavior" do
-          allow(shipment.order).to receive(:approved?).and_return(true)
           expect(shipment).to receive(:determine_state).with(shipment.order)
           subject
-        end
-      end
-    end
-
-    context "without a risky order" do
-      before { allow(shipment.order).to receive(:is_risky?).and_return(false) }
-
-      it "defaults to existing behavior" do
-        expect(shipment).to receive(:determine_state).with(shipment.order)
-        subject
-      end
-    end
-
-    context "shipment state" do
-      [:shipped, :ready].each do |state|
-        context "the shipment is #{state}" do
-          before { shipment.update_columns(state: state) }
-          it "defaults to existing behavior" do
-            expect(shipment).to receive(:determine_state).with(shipment.order)
-            subject
-          end
-        end
-      end
-
-      [:pending, :canceled].each do |state|
-        context "the shipment is #{state}" do
-          before { shipment.update_columns(state: state) }
-          it "is pending" do
-            expect(subject).to eq "pending"
-          end
         end
       end
     end

--- a/spec/models/spree/shipment_spec.rb
+++ b/spec/models/spree/shipment_spec.rb
@@ -5,7 +5,7 @@ describe Spree::Shipment, :type => :model do
   let(:shipment) { create(:shipment) }
   subject { shipment.determine_state(shipment.order) }
 
-  describe "#determine_state_with_signifyd" do
+  describe "#determine_state" do
     context "with a canceled order" do
       before do
         shipment.order.update(state: 'canceled')
@@ -23,14 +23,33 @@ describe Spree::Shipment, :type => :model do
       it "pending shipments remain pending" do
         expect(subject).to eq "pending"
       end
-    end
 
-    [:shipped, :ready].each do |state|
-      context "the shipment is #{state}" do
-        before { shipment.update(state: state) }
-        it "defaults to existing behavior" do
-          expect(shipment).to receive(:determine_state).with(shipment.order)
-          subject
+      describe "regular Solidus behaviour" do
+        context "order cannot ship" do
+          before { allow(shipment.order).to receive_messages can_ship?: false }
+
+          it 'returns pending' do
+            expect(subject).to eq 'pending'
+          end
+        end
+
+        context "order can ship" do
+          before { allow(shipment.order).to receive_messages can_ship?: true }
+
+          it 'returns shipped when already shipped' do
+            allow(shipment).to receive_messages state: 'shipped'
+            expect(subject).to eq 'shipped'
+          end
+
+          it 'returns pending when unpaid' do
+            allow(shipment.order).to receive_messages paid?: false
+            expect(subject).to eq 'pending'
+          end
+
+          it 'returns ready when paid' do
+            allow(shipment.order).to receive_messages paid?: true
+            expect(subject).to eq 'ready'
+          end
         end
       end
     end


### PR DESCRIPTION
In an effort to prevent one shipment state flip flop, I believe that another was inadvertently introduced. Any order update would cause canceled shipments to be returned to pending, which has implications for stores that allow backorders.

We are now recreating some of the default `determine_state` behaviour inside of our override, and if it gets any worse we'll probably just not want to bother calling super at all.

For now I would definitely like canceled shipments to remain canceled, but the original solidus_signifyd desire to prevent shipment readying until SIGNIFYD has approved an order can stay.