### PR TITLE
Update AMS

### DIFF
--- a/app/serializers/spree_signifyd/address_serializer.rb
+++ b/app/serializers/spree_signifyd/address_serializer.rb
@@ -2,8 +2,6 @@ require 'active_model_serializers'
 
 module SpreeSignifyd
   class AddressSerializer < ActiveModel::Serializer
-    self.root = false
-
     attributes :address
 
     def address

--- a/app/serializers/spree_signifyd/address_serializer.rb
+++ b/app/serializers/spree_signifyd/address_serializer.rb
@@ -1,4 +1,4 @@
-require 'active_model/serializer'
+require 'active_model_serializers'
 
 module SpreeSignifyd
   class AddressSerializer < ActiveModel::Serializer

--- a/app/serializers/spree_signifyd/billing_address_serializer.rb
+++ b/app/serializers/spree_signifyd/billing_address_serializer.rb
@@ -1,4 +1,4 @@
-require 'active_model/serializer'
+require 'active_model_serializers'
 
 module SpreeSignifyd
   class BillingAddressSerializer < AddressSerializer

--- a/app/serializers/spree_signifyd/billing_address_serializer.rb
+++ b/app/serializers/spree_signifyd/billing_address_serializer.rb
@@ -2,7 +2,7 @@ require 'active_model_serializers'
 
 module SpreeSignifyd
   class BillingAddressSerializer < AddressSerializer
-    def attributes
+    def attributes(*args)
       hash = {}
       hash['billingAddress'] = address
       hash

--- a/app/serializers/spree_signifyd/billing_address_serializer.rb
+++ b/app/serializers/spree_signifyd/billing_address_serializer.rb
@@ -2,8 +2,6 @@ require 'active_model_serializers'
 
 module SpreeSignifyd
   class BillingAddressSerializer < AddressSerializer
-    self.root = false
-
     def attributes
       hash = {}
       hash['billingAddress'] = address

--- a/app/serializers/spree_signifyd/credit_card_serializer.rb
+++ b/app/serializers/spree_signifyd/credit_card_serializer.rb
@@ -1,4 +1,4 @@
-require 'active_model/serializer'
+require 'active_model_serializers'
 
 module SpreeSignifyd
   class CreditCardSerializer < ActiveModel::Serializer

--- a/app/serializers/spree_signifyd/credit_card_serializer.rb
+++ b/app/serializers/spree_signifyd/credit_card_serializer.rb
@@ -2,8 +2,6 @@ require 'active_model_serializers'
 
 module SpreeSignifyd
   class CreditCardSerializer < ActiveModel::Serializer
-    self.root = false
-
     attributes :cardHolderName, :last4
 
     # this is how to conditionally include attributes in AMS

--- a/app/serializers/spree_signifyd/delivery_address_serializer.rb
+++ b/app/serializers/spree_signifyd/delivery_address_serializer.rb
@@ -2,8 +2,6 @@ require 'active_model_serializers'
 
 module SpreeSignifyd
   class DeliveryAddressSerializer < AddressSerializer
-    self.root = false
-
     def attributes
       hash = {}
       hash['deliveryAddress'] = address

--- a/app/serializers/spree_signifyd/delivery_address_serializer.rb
+++ b/app/serializers/spree_signifyd/delivery_address_serializer.rb
@@ -1,4 +1,4 @@
-require 'active_model/serializer'
+require 'active_model_serializers'
 
 module SpreeSignifyd
   class DeliveryAddressSerializer < AddressSerializer

--- a/app/serializers/spree_signifyd/delivery_address_serializer.rb
+++ b/app/serializers/spree_signifyd/delivery_address_serializer.rb
@@ -2,7 +2,7 @@ require 'active_model_serializers'
 
 module SpreeSignifyd
   class DeliveryAddressSerializer < AddressSerializer
-    def attributes
+    def attributes(*args)
       hash = {}
       hash['deliveryAddress'] = address
       hash['fullName'] = object.full_name

--- a/app/serializers/spree_signifyd/line_item_serializer.rb
+++ b/app/serializers/spree_signifyd/line_item_serializer.rb
@@ -1,4 +1,4 @@
-require 'active_model/serializer'
+require 'active_model_serializers'
 
 module SpreeSignifyd
   class LineItemSerializer < ActiveModel::Serializer

--- a/app/serializers/spree_signifyd/line_item_serializer.rb
+++ b/app/serializers/spree_signifyd/line_item_serializer.rb
@@ -2,8 +2,6 @@ require 'active_model_serializers'
 
 module SpreeSignifyd
   class LineItemSerializer < ActiveModel::Serializer
-    self.root = false
-
     attributes :itemId, :itemName, :itemQuantity, :itemPrice
 
     def itemId

--- a/app/serializers/spree_signifyd/order_serializer.rb
+++ b/app/serializers/spree_signifyd/order_serializer.rb
@@ -2,8 +2,7 @@ require 'active_model_serializers'
 
 module SpreeSignifyd
   class OrderSerializer < ActiveModel::Serializer
-    attributes :purchase, :recipient, :card
-    has_one :user, serializer: SpreeSignifyd::UserSerializer, root: "userAccount"
+    attributes :purchase, :recipient, :card, :userAccount
 
     def purchase
       build_purchase_information.tap do |purchase_info|
@@ -30,6 +29,11 @@ module SpreeSignifyd
       end
 
       card
+    end
+
+    def userAccount
+      return {} unless object.user
+      UserSerializer.new(object.user).serializable_hash
     end
 
     private

--- a/app/serializers/spree_signifyd/order_serializer.rb
+++ b/app/serializers/spree_signifyd/order_serializer.rb
@@ -1,4 +1,4 @@
-require 'active_model/serializer'
+require 'active_model_serializers'
 
 module SpreeSignifyd
   class OrderSerializer < ActiveModel::Serializer

--- a/app/serializers/spree_signifyd/order_serializer.rb
+++ b/app/serializers/spree_signifyd/order_serializer.rb
@@ -2,8 +2,6 @@ require 'active_model_serializers'
 
 module SpreeSignifyd
   class OrderSerializer < ActiveModel::Serializer
-    self.root = false
-
     attributes :purchase, :recipient, :card
     has_one :user, serializer: SpreeSignifyd::UserSerializer, root: "userAccount"
 

--- a/app/serializers/spree_signifyd/order_serializer.rb
+++ b/app/serializers/spree_signifyd/order_serializer.rb
@@ -14,7 +14,7 @@ module SpreeSignifyd
     end
 
     def recipient
-      recipient = SpreeSignifyd::DeliveryAddressSerializer.new(object.ship_address).serializable_object
+      recipient = SpreeSignifyd::DeliveryAddressSerializer.new(object.ship_address).serializable_hash
       recipient[:confirmationEmail] = object.email
       recipient[:fullName] = object.ship_address.full_name
       recipient
@@ -25,8 +25,8 @@ module SpreeSignifyd
       card = {}
 
       if payment_source.present? && payment_source.instance_of?(Spree::CreditCard)
-        card = CreditCardSerializer.new(payment_source).serializable_object
-        card.merge!(SpreeSignifyd::BillingAddressSerializer.new(object.bill_address).serializable_object)
+        card = CreditCardSerializer.new(payment_source).serializable_hash
+        card.merge!(SpreeSignifyd::BillingAddressSerializer.new(object.bill_address).serializable_hash)
       end
 
       card
@@ -55,7 +55,7 @@ module SpreeSignifyd
       order_products = []
 
       object.line_items.each do |li|
-        serialized_line_item = SpreeSignifyd::LineItemSerializer.new(li).serializable_object
+        serialized_line_item = SpreeSignifyd::LineItemSerializer.new(li).serializable_hash
         order_products << serialized_line_item
       end
 

--- a/app/serializers/spree_signifyd/user_serializer.rb
+++ b/app/serializers/spree_signifyd/user_serializer.rb
@@ -1,4 +1,4 @@
-require 'active_model/serializer'
+require 'active_model_serializers'
 
 module SpreeSignifyd
   class UserSerializer < ActiveModel::Serializer

--- a/app/serializers/spree_signifyd/user_serializer.rb
+++ b/app/serializers/spree_signifyd/user_serializer.rb
@@ -2,8 +2,6 @@ require 'active_model_serializers'
 
 module SpreeSignifyd
   class UserSerializer < ActiveModel::Serializer
-    self.root = false
-
     attributes :emailAddress, :username, :createdDate, :lastUpdateDate, :aggregateOrderCount, :aggregateOrderDollars, :phone
 
     # this is how to conditionally include attributes in AMS

--- a/solidus_signifyd.gemspec
+++ b/solidus_signifyd.gemspec
@@ -3,7 +3,7 @@
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = "solidus_signifyd"
-  s.version     = "1.1.0"
+  s.version     = "1.2.0"
   s.summary     = "Solidus extension for communicating with Signifyd to check orders for fraud."
   s.description = s.summary
 

--- a/solidus_signifyd.gemspec
+++ b/solidus_signifyd.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.require_path = "lib"
   s.requirements << "none"
 
-  s.add_dependency "active_model_serializers", "0.9.3"
+  s.add_dependency "active_model_serializers", "~> 0.10.7"
   s.add_dependency "signifyd", "~> 0.1.5"
   s.add_dependency "solidus_core", [">= 1.0", "< 3"]
   s.add_dependency "solidus_api", [">= 1.0", "< 3"]


### PR DESCRIPTION
Someone reported on Slack today that solidus_signifyd didn't work with AMS 0.10.0

Unfortunately in the 2 years since I last touched this gem the AMS project has gone into hibernation. I considered switching the serializers in this gem to jsonapi-rb or something similar, but that would be a non-trivial change and after looking at the specs I didn't have the confidence to do it quickly and safely.

Although AMS is now a little stale, the 0.10.0 branch is probably still _fine_ for most purposes. So this PR is my slapdash update. It's the quickest way I could make the existing specs green. I no longer work on any projects that use this gem and I don't have a huge desire to make a new one to find out if this is sufficient.

So I would really appreciate someone who has this on a working store to give it a thumbs up before we merge.